### PR TITLE
Fix compile errors

### DIFF
--- a/libcxl.c
+++ b/libcxl.c
@@ -895,7 +895,7 @@ int cxl_read_event(struct cxl_afu_h *afu, struct cxl_event *event)
 	if (event_cached(afu)) {
 		rc = fetch_cached_event(afu, event);
 		if (p)
-			free(p)
+			free(p);
 		return rc;
 	}
 

--- a/libcxl.h
+++ b/libcxl.h
@@ -218,7 +218,7 @@ int cxl_mmio_read32(struct cxl_afu_h *afu, uint64_t offset, uint32_t *data);
  *
  * Call this once per process prior to any MMIO accesses.
  */
-int cxl_mmio_install_sigbus_handler();
+int cxl_mmio_install_sigbus_handler(void);
 
 /**
  * Returns the size of afu_err_buff in bytes.


### PR DESCRIPTION
Add forgotten ; and correct function prototype, such that it compiles
with more strict warnings/error compiler settings.